### PR TITLE
fix: improve devcontainer setup with proper locale and package instal…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,15 +1,23 @@
 FROM gentoo/stage3:amd64-systemd
 
 # Use binary packages
-RUN echo 'FEATURES="getbinpkg binpkg-request-signature"' >> /etc/portage/make.conf
+RUN echo 'FEATURES="getbinpkg binpkg-request-signature -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
+
+# install nodejs with USE=npm
+RUN echo 'net-libs/nodejs npm' >> /etc/portage/package.use/nodejs
+
+# install english language as per official Gentoo documentation
+RUN echo 'LANG="en_US.UTF-8"' >> /etc/locale.conf && \
+    sed -i 's/#en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
 
 # Install packages for gentoo development
 RUN emerge-webrsync
-RUN emerge app-admin/sudo
-RUN emerge app-portage/gentoolkit
-RUN emerge dev-util/pkgcheck
-RUN emerge dev-util/pkgdev
-RUN USE=npm emerge net-libs/nodejs
+RUN emerge app-admin/sudo \
+           app-portage/gentoolkit \
+           dev-util/pkgcheck \
+           dev-util/pkgdev \
+           net-libs/nodejs
 
 # Set up non-root user
 ARG USERNAME=node


### PR DESCRIPTION
…lation

- Disable sandbox features for container compatibility
- Add USE flag for nodejs npm support
- Configure English locale properly following Gentoo documentation
- Consolidate package installation into single emerge command for efficiency